### PR TITLE
Update 20170711111306_Initial.php

### DIFF
--- a/config/Migrations/20170711111306_Initial.php
+++ b/config/Migrations/20170711111306_Initial.php
@@ -38,12 +38,12 @@ class Initial extends AbstractMigration
                 'null' => false,
             ])
             ->addColumn('threads_count', 'integer', [
-                'default' => null,
+                'default' => 0,
                 'limit' => 11,
                 'null' => false,
             ])
             ->addColumn('replies_count', 'integer', [
-                'default' => null,
+                'default' => 0,
                 'limit' => 11,
                 'null' => false,
             ])


### PR DESCRIPTION
Table "forum_categories", 
=> column "threads_count" and 
=> column "replies_count" 
needed a default value.
Otherwise you cant insert a new category when calling "your-domain.com/forum/admin/categories/add"